### PR TITLE
feat: Add health check for lightship NVMe drives

### DIFF
--- a/modules/nixos/hosts/lightship/default.nix
+++ b/modules/nixos/hosts/lightship/default.nix
@@ -221,6 +221,15 @@ in
 
       services = {
 
+        health-reporter = {
+          enable = true;
+          telegramTokenPath = config.sops.secrets.health_reporter_bot_api_token.path;
+          telegramChatIdPath = config.sops.secrets.telegram_chat_id.path;
+          checkReadOnlyMounts = [ "/mnt/nvme/*" ];
+          runAtBoot = true;
+          reportTime = "08:00";
+        };
+
         monitoring.alloy.enable = mkForce false;
 
         k8s = {

--- a/packages/health-report/health-report.py
+++ b/packages/health-report/health-report.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import psutil
 import requests
 import shutil
+import glob
 from hurry.filesize import size
 
 # Configure logging
@@ -809,9 +810,21 @@ class ReadOnlySection(ReportSection):
     def _check_ro_mounts(self):
         mounts_to_check = self.config.get("check_read_only_mounts", [])
         ro_detected = []
-        for mount in mounts_to_check:
-             if self._is_readonly(mount):
-                 ro_detected.append(mount)
+        for pattern in mounts_to_check:
+             # Expand glob patterns
+             expanded_mounts = glob.glob(pattern)
+             if not expanded_mounts:
+                 # If pattern doesn't match anything, maybe it's a literal path that doesn't exist yet or isn't globbable
+                 # Check if it looks like a glob pattern
+                 if any(char in pattern for char in ['*', '?', '[']):
+                     logger.warning(f"Pattern {pattern} did not match any files/directories")
+                 else:
+                     # Treat as literal
+                     expanded_mounts = [pattern]
+
+             for mount in expanded_mounts:
+                 if self._is_readonly(mount):
+                     ro_detected.append(mount)
         return ro_detected
 
     def _is_readonly(self, path):


### PR DESCRIPTION
Enable health-reporter service on lightship nodes to monitor NVMe drive health and read-only status.
- Configure health-reporter in modules/nixos/hosts/lightship/default.nix to check /mnt/nvme/*
- Update packages/health-report/health-report.py to support glob patterns in check_read_only_mounts

---
*PR created automatically by Jules for task [184471675494042888](https://jules.google.com/task/184471675494042888) started by @ProjectInitiative*