### PR TITLE
feat: implement group 1 ha router setup

### DIFF
--- a/docs/architecture/decisions/0001-ha-router-setup-plan.md
+++ b/docs/architecture/decisions/0001-ha-router-setup-plan.md
@@ -1,9 +1,11 @@
 # 0001: HA Router Setup Architecture Plan
 
 ## Context
+
 We need to build a High Availability (HA) NixOS router setup utilizing two rockchip-based nodes: **Topsail** (Primary) and **StormJib** (Backup). The goal is to provide a robust, automated network gateway with minimal downtime, automatic failover, multi-WAN load balancing/failover, failsafe rollbacks, comprehensive monitoring, and migration tooling for existing OpenWrt configurations. This infrastructure will also serve as a foundation for advanced local NPU-accelerated network analysis.
 
 ## Goals
+
 - Build a common, role-aware NixOS module system (`masthead`) for both routers.
 - Implement HA-aware failover and seamless switching (Keepalived/VRRP, MAC spoofing, dynamic WAN IP handling).
 - Support Multi-WAN configurations (load balancing and failover across multiple ISP connections).
@@ -21,8 +23,10 @@ We need to build a High Availability (HA) NixOS router setup utilizing two rockc
 To ensure efficient, conflict-free parallel development, tasks are divided into distinct functional groups. Each sub-agent can operate independently within their designated scope and file paths.
 
 ### Group 1: Core Base & Networking Foundations (The `masthead` Module)
+
 **Focus:** Define the declarative network topology and the base router module.
 **Tasks:**
+
 1. Create the base NixOS module `modules/nixos/hosts/masthead/default.nix`.
 2. Define role options: `config.projectinitiative.hosts.masthead.role = "primary" | "backup"`.
 3. Implement declarative network configurations for interfaces, VLANs, and bridges (`networking.vlans`, `networking.bridges`).
@@ -30,66 +34,81 @@ To ensure efficient, conflict-free parallel development, tasks are divided into 
 5. Create the specific host definition for `topsail` (similar to the existing `stormjib` host, but with the primary role).
 
 ### Group 2: High Availability & Multi-WAN Failover (VRRP/Keepalived/MWAN3)
+
 **Focus:** Handle seamless LAN gateway VIPs, WAN connection failover, and Multi-WAN load balancing.
 **Tasks:**
+
 1. Integrate `keepalived` for VRRP to manage local Gateway VIPs on LAN interfaces.
 2. Develop Multi-WAN logic (e.g., using policy-based routing with `iproute2` or evaluating packages like `mwan3` equivalents in NixOS). This must handle dynamic WAN IP acquisition, health checks across multiple ISPs, and connection tracking during WAN failover.
 3. **MAC Spoofing & Scripts:** Standard VRRP VMACs can cause issues with strict ISP modems. Explicitly define that WAN MAC spoofing will be handled via `keepalived`'s `notify_master` and `notify_fault` shell scripts to dynamically rewrite the physical interface MAC on the backup node only upon promotion.
 4. **State Sync:** Isolate `conntrackd` state synchronization on a dedicated sync VLAN between the primary and backup nodes to prevent broadcast storms or state manipulation on the primary LAN.
 5. **Failover Topologies:** Expand the failover logic to support multiple architecture combinations rather than exclusively relying on VIP/MAC spoofing. Include support for:
-    - **Administrative Link State:** Keeping the backup node's WAN ports administratively disabled until a VRRP state change triggers them to activate.
-    - **Hybrid NAT/Passthrough:** A split design where the primary internet uses IP passthrough to the primary node, while a metered connection (like Starlink) leverages its built-in router to provide a double-NAT connection directly to the backup node.
+   - **Administrative Link State:** Keeping the backup node's WAN ports administratively disabled until a VRRP state change triggers them to activate.
+   - **Hybrid NAT/Passthrough:** A split design where the primary internet uses IP passthrough to the primary node, while a metered connection (like Starlink) leverages its built-in router to provide a double-NAT connection directly to the backup node.
 
 ### Group 3: Failsafe & Safe Rollbacks
+
 **Focus:** Prevent permanent lockouts from bad network configurations.
 **Tasks:**
+
 1. **Push-Based Deployment Integration:** Discard local wrapper scripts and pull-based agents (like `comin`). Design the failsafe mechanism to integrate directly with a push-based deployment pipeline (tool TBD).
 2. **Validation Pipeline:** The deployment workflow must push the Nix closure, activate the configuration, and execute a suite of remote validation checks (e.g., verifying gateway reachability, checking active routing tables, and confirming SSH connectivity). If these validation checks fail or time out, the deployment pipeline must automatically initiate a rollback on the target node.
 
 ### Group 4: Metrics, Monitoring, & Telemetry
+
 **Focus:** Extend the existing observability stack to capture router-specific data.
 **Tasks:**
+
 1. Ensure `prometheus-node-exporter` is collecting all relevant network interface metrics.
 2. Deploy exporters for HA and routing specific services: `keepalived-exporter`, multi-WAN health check statuses, and DHCP metrics (e.g., `kea-exporter`).
 3. Export firewall/conntrack statistics.
 4. Create Grafana dashboard JSON models for HA status, WAN failover events, load balancing distribution, and per-VLAN bandwidth utilization.
 
 ### Group 5: OpenWrt Migration Agent
+
 **Focus:** Automate the translation of legacy OpenWrt configurations to declarative Nix.
 **Tasks:**
+
 1. **Phase 1 (Data Acquisition):** Do not build a raw text parser for `/etc/config/*`. Instead, the migration process should dictate running `ubus call uci get_all` on the existing OpenWrt device to dump the configuration as a clean JSON object.
 2. **Phase 2 (Generate):** The Python script in `packages/openwrt-migrator/` will ingest that JSON directly to generate the Nix module (`openwrt-migrated.nix`) compatible with the `masthead` structure.
 
 ### Group 6: Testing Framework (NixOS VMs)
+
 **Focus:** Create reproducible, isolated tests for the HA routing and Multi-WAN logic.
 **Tasks:**
+
 1. Develop a NixOS integration test under a new directory `tests/router-ha/`.
 2. **Architecture Optimization:** To avoid severe CPU overhead during iteration, explicitly evaluate the router VMs as `x86_64-linux` for the test suite. The routing, VRRP, and multi-WAN logic is architecture-agnostic and will validate properly on the host architecture before deploying to the target ARM boards.
 3. Spin up a simulated network containing: 2 Router VMs (Primary/Backup), 2 simulated ISP gateways (for Multi-WAN), and 2 Client VMs on different subnets.
 4. Write Python test scripts within `nixosTest` to verify:
-    - Clients successfully acquire IPs via DHCP.
-    - Traffic is correctly load-balanced across multiple WAN links.
-    - Traffic routes correctly through the VIP.
-    - Failover scenarios:
-      - (a) Disconnect ISP1, verify traffic shifts to ISP2.
-      - (b) Intentionally crash the Primary Router, verify the Backup assumes the VIP, Spoofed MAC, and restores client connectivity to active ISPs within expected time constraints.
+   - Clients successfully acquire IPs via DHCP.
+   - Traffic is correctly load-balanced across multiple WAN links.
+   - Traffic routes correctly through the VIP.
+   - Failover scenarios:
+     - (a) Disconnect ISP1, verify traffic shifts to ISP2.
+     - (b) Intentionally crash the Primary Router, verify the Backup assumes the VIP, Spoofed MAC, and restores client connectivity to active ISPs within expected time constraints.
 
 ### Group 7: NPU AI Network Analysis
+
 **Focus:** Leverage the Rockchip RK3588 NPU for local traffic analysis using mainline Linux kernel features.
 **Tasks:**
+
 1. Configure NixOS to use the recently upstreamed open-source `rocket` driver and `mesa` for NPU support (avoiding the proprietary RKNN toolkit as we run mainline kernels).
 2. Configure a port mirror or NFLOG target to forward traffic headers to a local analysis service.
 3. **Model Integration:** Build or adapt a lightweight PyTorch or TensorFlow model for traffic anomaly detection that successfully compiles for the `rocket`/`mesa` NPU pipeline, mirroring the approach used for local Frigate models. Feed identified events into the centralized monitoring stack.
 
 ### Group 8: Dynamic QoS & Metered WAN Traffic Shaping
+
 **Focus:** Implement priority balancing and throttling based on the active WAN interface's link properties.
 **Tasks:**
+
 1. Design a configuration schema mapping specific subnets/MACs to priority tiers (e.g., `Critical`, `Standard`, `Throttled`, `Blocked`).
 2. Create `tc` (Traffic Control) or `nftables` QoS rules to enforce these tiers.
 3. **QoS Triggers:** Tie the dynamic QoS and `nftables` traffic shaping directly into the `keepalived` state change scripts (`notify_master`/`notify_fault`). This ensures the metered/Starlink throttling profile applies instantly upon failover, without waiting for a polling daemon to notice the WAN shift. When failing over to a metered connection, automatically clamp bandwidth for non-essential subnets and prioritize the critical "work" subnet.
 4. Integrate testing for these QoS tiers into the `tests/router-ha/` framework, simulating a metered failover and verifying bandwidth limits between test clients.
 
 ## Proposed File Structure
+
 - `modules/nixos/hosts/masthead/` -> Core router configurations, VRRP definitions, Multi-WAN logic, QoS logic, role logic.
 - `modules/nixos/services/router-failsafe/` -> Configuration and scripts for auto-rollback.
 - `packages/openwrt-migrator/` -> Python scripts for OpenWrt config translation.

--- a/modules/nixos/hosts/masthead/default.nix
+++ b/modules/nixos/hosts/masthead/default.nix
@@ -15,224 +15,113 @@ in
 {
   options.${namespace}.hosts.masthead = with types; {
     enable = mkBoolOpt false "Whether or not to enable the masthead router base config.";
+    role = mkOpt (types.enum [
+      "primary"
+      "backup"
+    ]) "primary" "The role of the masthead router.";
   };
 
-  #  config = mkIf cfg.enable {
+  config = mkIf cfg.enable {
+    # Declarative network configurations for interfaces, VLANs, and bridges
+    networking.bridges = {
+      lan0 = {
+        interfaces = [ ];
+      };
+    };
 
-  #  projectinitiative.hosts.base-router = {
-  #    enable = true;
+    networking.vlans = {
+      vlan1 = {
+        id = 1;
+        interface = "lan0";
+      };
+      vlan10 = {
+        id = 10;
+        interface = "lan0";
+      };
+      vlan21 = {
+        id = 21;
+        interface = "lan0";
+      };
+      vlan22 = {
+        id = 22;
+        interface = "lan0";
+      };
+      vlan30 = {
+        id = 30;
+        interface = "lan0";
+      };
+    };
 
-  #    # Interface names
-  #    wanInterface = "wan0";
-  #    lanInterface = "lan0";
+    # Configure DNS resolvers
+    networking.nameservers = [
+      "1.1.1.1"
+      "9.9.9.9"
+    ];
 
-  #    # Management VLAN configuration
-  #    managementVlan = {
-  #      id = 1;  # Untagged VLAN
-  #      network = "172.16.1.0/24";
-  #      primaryIp = "172.16.1.2";  # Primary router's IP
-  #      backupIp = "172.16.1.3";   # Backup router's IP
-  #      virtualIp = "172.16.1.1";  # Virtual IP for management
-  #    };
+    # Configure DHCP server using Kea
+    services.kea.dhcp4 = {
+      enable = true;
+      settings = {
+        interfaces-config = {
+          interfaces = [
+            "vlan10"
+            "vlan21"
+            "vlan22"
+            "vlan30"
+          ];
+        };
+        hooks-libraries = [
+          {
+            library = "${pkgs.kea}/lib/kea/hooks/libdhcp_lease_cmds.so";
+          }
+          {
+            library = "${pkgs.kea}/lib/kea/hooks/libdhcp_ha.so";
+            parameters = {
+              high-availability = [
+                {
+                  this-server-name = "router-${cfg.role}";
+                  mode = "hot-standby";
+                  heartbeat-delay = 10000;
+                  max-response-delay = 60000;
+                  max-ack-delay = 10000;
+                  max-unacked-clients = 5;
+                  peers = [
+                    {
+                      name = "router-primary";
+                      url = "http://172.16.1.2:8000/";
+                      role = "primary";
+                    }
+                    {
+                      name = "router-backup";
+                      url = "http://172.16.1.3:8000/";
+                      role = "standby";
+                    }
+                  ];
+                }
+              ];
+            };
+          }
+        ];
 
-  #    # VRRP base configuration
-  #    vrrp = {
-  #      enable = true;
-  #      routerId = 10;
-  #      authPass = "your_vrrp_password_here";  # Use sops-nix in production
-
-  #      # These will be overridden by host-specific configurations
-  #      # priority = set in host config
-  #      # peerAddress = set in host config
-  #    };
-
-  #    # DNS configuration
-  #    dnsServers = [
-  #      "1.1.1.1"
-  #      "9.9.9.9"
-  #    ];
-
-  #    # DHCP configuration
-  #    # For home network using existing DHCP server:
-  #    dhcpMode = "external";
-  #    externalDhcpServer = "192.168.1.1";  # Your home router's IP
-  # --- Router Configuration (using base-router module) ---
-  # ${namespace}.router = {
-  #   enable = true;
-  #   routerRole = routerRole; # Pass role defined above
-
-  #   # --- Interfaces ---
-  #   wanInterface = "eth0"; # Adjust to your hardware
-  #   lanInterface = "eth1"; # Adjust to your hardware
-
-  #   # --- Management Network ---
-  #   managementVlan = {
-  #     id = 10; # Tagged management VLAN
-  #     network = "172.16.10.0/24";
-  #     primaryIp = "172.16.10.2";
-  #     backupIp = "172.16.10.3";
-  #     virtualIp = "172.16.10.1";
-  #     # enableDhcp = false; # Default is false
-  #   };
-
-  #   # --- User VLANs ---
-  #   vlans = [
-  #     {
-  #       id = 20;
-  #       name = "users";
-  #       network = "192.168.20.0/24";
-  #       primaryIp = "192.168.20.2";
-  #       backupIp = "192.168.20.3";
-  #       virtualIp = "192.168.20.1";
-  #       enableDhcp = true;
-  #       dhcpRangeStart = "192.168.20.100";
-  #       dhcpRangeEnd = "192.168.20.200";
-  #     }
-  #     {
-  #       id = 30;
-  #       name = "iot";
-  #       network = "192.168.30.0/24";
-  #       primaryIp = "192.168.30.2";
-  #       backupIp = "192.168.30.3";
-  #       virtualIp = "192.168.30.1";
-  #       enableDhcp = true;
-  #       dhcpRangeStart = "192.168.30.50";
-  #       dhcpRangeEnd = "192.168.30.150";
-  #       isolated = true; # Isolate this VLAN
-  #     }
-  #   ];
-
-  #   # --- WAN IP ---
-  #   externalStaticIp = {
-  #     address = "YOUR_STATIC_IP";
-  #     prefixLength = 24; # Your prefix length
-  #     gateway = "YOUR_GATEWAY_IP";
-  #   };
-  #   # Or set externalStaticIp = null; to use DHCP on WAN
-
-  #   # --- DNS ---
-  #   dnsServers = [ "9.9.9.9" "1.1.1.1" ]; # Override defaults if needed
-  #   dnsCacheSize = 2000; # Customize DNS cache
-
-  #   # --- DHCP ---
-  #   keaDhcp4.enable = true;
-  #   keaDhcp4.failover = mkIf config.${namespace}.hosts.base-router.vrrp.enable { # Enable failover only if VRRP is enabled
-  #      # Parameters are mostly defaults, adjust if needed
-  #      mclt = 1800; # Example override
-  #   };
-
-  #    # For self-hosted DHCP, change to:
-  #    # dhcpMode = "internal";
-
-  #    # VLAN definitions shared between all routers
-  #    vlans = [
-  #      # IoT VLAN
-  #      {
-  #        id = 21;
-  #        name = "iot";
-  #        network = "192.168.21.0/24";
-  #        virtualIp = "192.168.21.1";  # VRRP address for clients
-  #        primaryIp = "192.168.21.2";  # Primary router's IP
-  #        backupIp = "192.168.21.3";   # Backup router's IP
-  #        enableDhcp = true;
-  #        dhcpRangeStart = "192.168.21.100";
-  #        dhcpRangeEnd = "192.168.21.250";
-  #        isolated = true;  # Isolate IoT devices from other networks
-  #      }
-
-  #      # Guest VLAN
-  #      {
-  #        id = 22;
-  #        name = "guest";
-  #        network = "192.168.22.0/24";
-  #        virtualIp = "192.168.22.1";
-  #        primaryIp = "192.168.22.2";
-  #        backupIp = "192.168.22.3";
-  #        enableDhcp = true;
-  #        dhcpRangeStart = "192.168.22.100";
-  #        dhcpRangeEnd = "192.168.22.250";
-  #        isolated = true;  # Isolate guest network
-  #      }
-
-  #      # Home network VLAN
-  #      {
-  #        id = 10;
-  #        name = "home";
-  #        network = "192.168.10.0/24";
-  #        virtualIp = "192.168.10.1";
-  #        primaryIp = "192.168.10.2";
-  #        backupIp = "192.168.10.3";
-  #        enableDhcp = true;
-  #        dhcpRangeStart = "192.168.10.100";
-  #        dhcpRangeEnd = "192.168.10.250";
-  #        isolated = false;  # Allow communication with other non-isolated VLANs
-  #      }
-
-  #      # Media VLAN
-  #      {
-  #        id = 30;
-  #        name = "media";
-  #        network = "192.168.30.0/24";
-  #        virtualIp = "192.168.30.1";
-  #        primaryIp = "192.168.30.2";
-  #        backupIp = "192.168.30.3";
-  #        enableDhcp = true;
-  #        dhcpRangeStart = "192.168.30.100";
-  #        dhcpRangeEnd = "192.168.30.250";
-  #        isolated = false;
-  #      }
-  #    ];
-
-  #    # Port forwarding rules (example)
-  #    portForwarding = [
-  #      {
-  #        sourcePort = 80;
-  #        destination = "192.168.10.50";
-  #        destinationPort = 80;
-  #        protocol = "tcp";
-  #      }
-  #      {
-  #        sourcePort = 443;
-  #        destination = "192.168.10.50";
-  #        destinationPort = 443;
-  #        protocol = "tcp";
-  #      }
-  #    ];
-  #  };
-
-  # };
-  #   # --- VRRP / Keepalived ---
-  #   vrrp.enable = true; # Enable HA
-  #   vrrp.virtualRouterIdBase = 50; # Customize base VRID
-  #   vrrp.priority = if routerRole == "primary" then 150 else 100; # Explicit priorities
-  #   # vrrp.authPass = "supersecret"; # Use authPassFile instead
-  #   vrrp.authPassFile = config.sops.secrets."keepalived_vrrp_password".path;
-  #   vrrp.keaFailoverPort = 647; # Ensure this matches Kea config if using failover
-
-  #   # --- Firewall ---
-  #   allowPingFromWan = false;
-  #   portForwarding = [
-  #     { sourcePort = 80; destination = "192.168.20.10"; protocol = "tcp"; description = "Web Server"; }
-  #     { sourcePort = 443; destination = "192.168.20.10"; protocol = "tcp"; }
-  #     { sourcePort = 1194; destination = "192.168.20.11"; destinationPort = 1194; protocol = "udp"; description = "OpenVPN"; }
-  #   ];
-
-  #   # --- Kernel ---
-  #   extraKernelModules = [ "wireguard" ]; # Example
-  #   extraSysctlSettings = {
-  #     "net.core.somaxconn" = 1024; # Example custom sysctl
-  #   };
-
-  # };
-
-  # # --- SOPS Configuration (Example) ---
-  # sops.secrets."keepalived_vrrp_password" = {
-  #     # mode = "0400"; # keepalived runs as root, default mode is fine
-  #     # owner = config.users.users.keepalived.name; # Not needed if root reads it
-  # };
-  # # sops.secrets."root_password" = {};
-
-  # # Disable NetworkManager as interfaces are manually configured by the router modules
-  # networking.networkmanager.enable = false;
-  # };
+        subnet4 = [
+          {
+            subnet = "192.168.10.0/24";
+            pools = [ { pool = "192.168.10.100 - 192.168.10.250"; } ];
+          }
+          {
+            subnet = "192.168.21.0/24";
+            pools = [ { pool = "192.168.21.100 - 192.168.21.250"; } ];
+          }
+          {
+            subnet = "192.168.22.0/24";
+            pools = [ { pool = "192.168.22.100 - 192.168.22.250"; } ];
+          }
+          {
+            subnet = "192.168.30.0/24";
+            pools = [ { pool = "192.168.30.100 - 192.168.30.250"; } ];
+          }
+        ];
+      };
+    };
+  };
 }

--- a/modules/nixos/hosts/masthead/stormjib/default.nix
+++ b/modules/nixos/hosts/masthead/stormjib/default.nix
@@ -27,6 +27,7 @@ in
 
     projectinitiative = {
       hosts.masthead.enable = true;
+      hosts.masthead.role = "backup";
     };
 
   };

--- a/modules/nixos/hosts/masthead/topsail/default.nix
+++ b/modules/nixos/hosts/masthead/topsail/default.nix
@@ -1,0 +1,25 @@
+{
+  options,
+  config,
+  lib,
+  pkgs,
+  namespace,
+  ...
+}:
+with lib;
+with lib.${namespace};
+let
+  cfg = config.${namespace}.hosts.masthead.topsail;
+in
+{
+  options.${namespace}.hosts.masthead.topsail = with types; {
+    enable = mkBoolOpt false "Whether or not to enable the topsail config.";
+  };
+
+  config = mkIf cfg.enable {
+    projectinitiative = {
+      hosts.masthead.enable = true;
+      hosts.masthead.role = "primary";
+    };
+  };
+}


### PR DESCRIPTION
Implement Group 1 of HA Router Setup Architecture Plan (ADR 0001)

This pull request implements the networking base and foundational node definitions for the new HA Router infrastructure.

**What**
- Added `topsail` host module acting as the `primary` role.
- Updated the existing `stormjib` host module to the `backup` role.
- Defined a `role` module option in the base `masthead` configuration.
- Rewrote the base `masthead` module to use declarative NixOS native network configurations (`networking.vlans`, `networking.bridges`) instead of placeholder comments.
- Configured a Kea DHCP service equipped with HA capabilities (`libdhcp_ha.so`), utilizing the defined roles to manage `hot-standby` failover.

**Why**
To fulfill the requirements defined in Group 1 of the HA Router Architecture Plan (`docs/architecture/decisions/0001-ha-router-setup-plan.md`), laying down the base Nix module structure and enabling the primary and backup logic.

**Verification**
- Validated via `nix eval` that the new modules evaluate correctly under the `projectinitiative` namespace.
- Formatted via the project treefmt configuration.

---
*PR created automatically by Jules for task [6686209141939855620](https://jules.google.com/task/6686209141939855620) started by @ProjectInitiative*