### PR TITLE
✨ feat(router): implement HA dynamic metered WAN QoS

### DIFF
--- a/modules/nixos/hosts/masthead/default.nix
+++ b/modules/nixos/hosts/masthead/default.nix
@@ -17,6 +17,7 @@ in
     ./vrrp
     ./multi-wan
     ./conntrack
+    ./qos
   ];
 
   options.${namespace}.hosts.masthead = with types; {

--- a/modules/nixos/hosts/masthead/qos/default.nix
+++ b/modules/nixos/hosts/masthead/qos/default.nix
@@ -1,0 +1,106 @@
+{
+  config,
+  lib,
+  pkgs,
+  namespace,
+  ...
+}:
+
+with lib;
+with lib.${namespace};
+let
+  cfg = config.${namespace}.hosts.masthead;
+  qosCfg = cfg.qos;
+
+  applyQosScript = pkgs.writeShellScript "apply-metered-qos" ''
+    #!/usr/bin/env bash
+    # Clear existing tc and nftables rules
+    ${pkgs.iproute2}/bin/tc qdisc del dev ${qosCfg.wanInterface} root 2>/dev/null || true
+    ${pkgs.nftables}/bin/nft delete table inet metered_qos 2>/dev/null || true
+
+    # Only apply on metered role when active
+    if [ "$1" = "${qosCfg.meteredRole}" ]; then
+      echo "Applying metered QoS profile on ${qosCfg.wanInterface}..."
+
+      # Setup root qdisc
+      ${pkgs.iproute2}/bin/tc qdisc add dev ${qosCfg.wanInterface} root handle 1: htb default 99
+
+      # Setup nftables table and chain for marking in the forward hook
+      ${pkgs.nftables}/bin/nft add table inet metered_qos
+      ${pkgs.nftables}/bin/nft add chain inet metered_qos forward { type filter hook forward priority 0 \; policy accept \; }
+
+      ${concatStringsSep "\n" (mapAttrsToList (name: tier: ''
+        ${optionalString (!tier.blocked) ''
+          # Class for ${name}
+          ${pkgs.iproute2}/bin/tc class add dev ${qosCfg.wanInterface} parent 1: classid 1:${toString tier.priority} htb rate ${tier.rate} ceil ${tier.ceil}
+          ${pkgs.iproute2}/bin/tc qdisc add dev ${qosCfg.wanInterface} parent 1:${toString tier.priority} handle ${toString tier.priority}0: sfq perturb 10
+          ${pkgs.iproute2}/bin/tc filter add dev ${qosCfg.wanInterface} protocol ip parent 1: prio 1 handle ${toString tier.priority} fw flowid 1:${toString tier.priority}
+        ''}
+      '') qosCfg.tiers)}
+
+      ${concatStringsSep "\n" (mapAttrsToList (name: tier: ''
+        ${concatMapStringsSep "\n" (subnet: ''
+          ${if tier.blocked then ''
+            # Drop traffic for ${subnet} via nftables (only when destined out WAN)
+            ${pkgs.nftables}/bin/nft add rule inet metered_qos forward oifname ${qosCfg.wanInterface} ip saddr ${subnet} drop
+          '' else ''
+            # Mark traffic for ${subnet} via nftables (only when destined out WAN)
+            ${pkgs.nftables}/bin/nft add rule inet metered_qos forward oifname ${qosCfg.wanInterface} ip saddr ${subnet} meta mark set 0x${toString tier.priority}
+          ''}
+        '') tier.subnets}
+
+        ${concatMapStringsSep "\n" (mac: ''
+          ${if tier.blocked then ''
+            # Drop traffic for MAC ${mac} via nftables (only when destined out WAN)
+            ${pkgs.nftables}/bin/nft add rule inet metered_qos forward oifname ${qosCfg.wanInterface} ether saddr ${mac} drop
+          '' else ''
+            # Mark traffic for MAC ${mac} via nftables (only when destined out WAN)
+            ${pkgs.nftables}/bin/nft add rule inet metered_qos forward oifname ${qosCfg.wanInterface} ether saddr ${mac} meta mark set 0x${toString tier.priority}
+          ''}
+        '') tier.macs}
+      '') qosCfg.tiers)}
+
+      # Default catch-all filter to something slow
+      ${pkgs.iproute2}/bin/tc class add dev ${qosCfg.wanInterface} parent 1: classid 1:99 htb rate 1mbit ceil 5mbit
+      ${pkgs.iproute2}/bin/tc qdisc add dev ${qosCfg.wanInterface} parent 1:99 handle 990: sfq perturb 10
+    else
+      echo "Standard connection active, no metered QoS applied."
+    fi
+  '';
+
+  removeQosScript = pkgs.writeShellScript "remove-metered-qos" ''
+    #!/usr/bin/env bash
+    ${pkgs.iproute2}/bin/tc qdisc del dev ${qosCfg.wanInterface} root 2>/dev/null || true
+    ${pkgs.nftables}/bin/nft delete table inet metered_qos 2>/dev/null || true
+  '';
+
+in
+{
+  options.${namespace}.hosts.masthead.qos = {
+    enable = mkBoolOpt false "Enable dynamic QoS and metered WAN traffic shaping.";
+    wanInterface = mkOpt types.str "wan0" "The WAN interface to apply QoS to.";
+    meteredRole = mkOpt types.str "backup" "The router role that corresponds to the metered connection.";
+    tiers = mkOpt (types.attrsOf (types.submodule {
+      options = {
+        priority = mkOpt types.int 1 "Priority tier id.";
+        rate = mkOpt types.str "1mbit" "Rate limit (e.g., '10mbit').";
+        ceil = mkOpt types.str "1mbit" "Ceil limit (e.g., '20mbit').";
+        subnets = mkOpt (types.listOf types.str) [] "Subnets mapping to this tier.";
+        macs = mkOpt (types.listOf types.str) [] "MAC addresses mapping to this tier.";
+        blocked = mkBoolOpt false "Whether this tier is entirely blocked on metered connection.";
+      };
+    })) {
+      critical = { priority = 10; rate = "50mbit"; ceil = "100mbit"; subnets = [ "192.168.10.0/24" ]; };
+      standard = { priority = 20; rate = "10mbit"; ceil = "50mbit"; subnets = [ "192.168.21.0/24" ]; };
+      throttled = { priority = 30; rate = "1mbit"; ceil = "5mbit"; subnets = [ "192.168.22.0/24" ]; };
+      blocked = { priority = 40; blocked = true; subnets = [ "192.168.30.0/24" ]; };
+    } "QoS Tiers.";
+
+    applyScript = mkOpt types.package applyQosScript "The generated script to apply QoS.";
+    removeScript = mkOpt types.package removeQosScript "The generated script to remove QoS.";
+  };
+
+  config = mkIf (cfg.enable && qosCfg.enable) {
+    environment.systemPackages = [ pkgs.iproute2 pkgs.nftables ];
+  };
+}

--- a/modules/nixos/hosts/masthead/vrrp/default.nix
+++ b/modules/nixos/hosts/masthead/vrrp/default.nix
@@ -29,9 +29,11 @@ in
         notifyMaster = "${pkgs.writeShellScript "notify-master-lan0" ''
           ${pkgs.iproute2}/bin/ip link set dev wan0 address ${cfg.wanMac}
           ${pkgs.iproute2}/bin/ip link set dev wan0 up
+          ${lib.optionalString cfg.qos.enable "${cfg.qos.applyScript} ${cfg.role}"}
         ''}";
         notifyBackup = "${pkgs.writeShellScript "notify-backup-lan0" ''
           ${pkgs.iproute2}/bin/ip link set dev wan0 down
+          ${lib.optionalString cfg.qos.enable "${cfg.qos.removeScript}"}
         ''}";
       };
       vlan10 = {

--- a/tests/router-ha/qos.nix
+++ b/tests/router-ha/qos.nix
@@ -1,0 +1,28 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  eval = pkgs.lib.evalModules {
+    modules = [
+      ../../modules/nixos/hosts/masthead/qos/default.nix
+      {
+        options.projectinitiative.hosts.masthead.enable = pkgs.lib.mkEnableOption "";
+        options.projectinitiative.hosts.masthead.role = pkgs.lib.mkOption { type = pkgs.lib.types.str; };
+        options.environment.systemPackages = pkgs.lib.mkOption { type = pkgs.lib.types.listOf pkgs.lib.types.package; };
+        config.projectinitiative.hosts.masthead.enable = true;
+        config.projectinitiative.hosts.masthead.role = "backup";
+        config.projectinitiative.hosts.masthead.qos.enable = true;
+      }
+    ];
+    specialArgs = {
+      namespace = "projectinitiative";
+      pkgs = pkgs;
+      lib = pkgs.lib // {
+        projectinitiative = {
+          mkOpt = type: default: description: pkgs.lib.mkOption { inherit type default description; };
+          mkBoolOpt = default: description: pkgs.lib.mkOption { type = pkgs.lib.types.bool; inherit default description; };
+        };
+      };
+    };
+  };
+in
+  eval.config.projectinitiative.hosts.masthead.qos.applyScript.outPath


### PR DESCRIPTION
Implements GROUP 8 functionality from the architecture plan. This introduces a dynamic Quality of Service (QoS) module that automatically shapes network traffic into distinct priority tiers when the High Availability router drops to a metered backup connection (e.g. Starlink).

*   Creates a generic QoS schema allowing subnets and MACs to be mapped into Priority, Rate, and Ceil tiers.
*   Uses `nftables` `forward` hooks to properly classify and drop traffic prior to egress SNAT logic.
*   Hooks directly into the existing VRRP `notify_master` and `notify_backup` events to instantly apply or remove the throttling profile upon failover.

---
*PR created automatically by Jules for task [11962091061811174818](https://jules.google.com/task/11962091061811174818) started by @ProjectInitiative*